### PR TITLE
Add comments to generated, exported types to satisfy golint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ stdout:
 ```go
 package main
 
+// GetterMock is a mock implementation of the {{ .Name }}
+// interface.
 type GetterMock struct {
 	GetByIDStub     func(id int) ([]string, error)
 	GetByIDCalled   int32
@@ -51,11 +53,15 @@ type GetterMock struct {
 
 var _ Getter = &GetterMock{}
 
+// GetByID is a stub for the Getter.GetByID
+// method that records the number of times it has been called.
 func (m *GetterMock) GetByID(id int) ([]string, error) {
 	atomic.AddInt32(m.GetByIDCalled, 1)
 	return m.GetByIDStub(id)
 }
 
+// GetByName is a stub for the Getter.GetByName
+// method that records the number of times it has been called.
 func (m *GetterMock) GetByName(name string) ([]string, error) {
 	atomic.AddInt32(m.GetByNameCalled, 1)
 	return m.GetByNameStub(name)

--- a/example/example.go
+++ b/example/example.go
@@ -10,6 +10,8 @@ import (
 // TODO: chan types
 // TODO: map types
 
+// MyInterface is a sample interface with a large number of
+// methods of different signatures.
 //go:generate mock -o mock.go MyInterface
 type MyInterface interface {
 	NoParamsOrReturn()

--- a/example/mock.go
+++ b/example/mock.go
@@ -8,6 +8,8 @@ import (
 	renamed "text/template"
 )
 
+// MyInterfaceMock is a mock implementation of the MyInterface
+// interface.
 type MyInterfaceMock struct {
 	NoParamsOrReturnStub                     func()
 	NoParamsOrReturnCalled                   int32
@@ -95,206 +97,288 @@ type MyInterfaceMock struct {
 
 var _ MyInterface = &MyInterfaceMock{}
 
+// NoParamsOrReturn is a stub for the MyInterface.NoParamsOrReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) NoParamsOrReturn() {
 	atomic.AddInt32(&m.NoParamsOrReturnCalled, 1)
 	m.NoParamsOrReturnStub()
 }
 
+// UnnamedParam is a stub for the MyInterface.UnnamedParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) UnnamedParam(param1 string) {
 	atomic.AddInt32(&m.UnnamedParamCalled, 1)
 	m.UnnamedParamStub(param1)
 }
 
+// UnnamedVariadicParam is a stub for the MyInterface.UnnamedVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) UnnamedVariadicParam(param1 ...string) {
 	atomic.AddInt32(&m.UnnamedVariadicParamCalled, 1)
 	m.UnnamedVariadicParamStub(param1...)
 }
 
+// BlankParam is a stub for the MyInterface.BlankParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) BlankParam(param1 string) {
 	atomic.AddInt32(&m.BlankParamCalled, 1)
 	m.BlankParamStub(param1)
 }
 
+// BlankVariadicParam is a stub for the MyInterface.BlankVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) BlankVariadicParam(param1 ...string) {
 	atomic.AddInt32(&m.BlankVariadicParamCalled, 1)
 	m.BlankVariadicParamStub(param1...)
 }
 
+// NamedParam is a stub for the MyInterface.NamedParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) NamedParam(str string) {
 	atomic.AddInt32(&m.NamedParamCalled, 1)
 	m.NamedParamStub(str)
 }
 
+// NamedVariadicParam is a stub for the MyInterface.NamedVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) NamedVariadicParam(strs ...string) {
 	atomic.AddInt32(&m.NamedVariadicParamCalled, 1)
 	m.NamedVariadicParamStub(strs...)
 }
 
+// SameTypeNamedParams is a stub for the MyInterface.SameTypeNamedParams
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) SameTypeNamedParams(str1 string, str2 string) {
 	atomic.AddInt32(&m.SameTypeNamedParamsCalled, 1)
 	m.SameTypeNamedParamsStub(str1, str2)
 }
 
+// ImportedParam is a stub for the MyInterface.ImportedParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) ImportedParam(tmpl template.Template) {
 	atomic.AddInt32(&m.ImportedParamCalled, 1)
 	m.ImportedParamStub(tmpl)
 }
 
+// ImportedVariadicParam is a stub for the MyInterface.ImportedVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) ImportedVariadicParam(tmpl ...template.Template) {
 	atomic.AddInt32(&m.ImportedVariadicParamCalled, 1)
 	m.ImportedVariadicParamStub(tmpl...)
 }
 
+// RenamedImportParam is a stub for the MyInterface.RenamedImportParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) RenamedImportParam(tmpl renamed.Template) {
 	atomic.AddInt32(&m.RenamedImportParamCalled, 1)
 	m.RenamedImportParamStub(tmpl)
 }
 
+// RenamedImportVariadicParam is a stub for the MyInterface.RenamedImportVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) RenamedImportVariadicParam(tmpls ...renamed.Template) {
 	atomic.AddInt32(&m.RenamedImportVariadicParamCalled, 1)
 	m.RenamedImportVariadicParamStub(tmpls...)
 }
 
+// DotImportParam is a stub for the MyInterface.DotImportParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) DotImportParam(file File) {
 	atomic.AddInt32(&m.DotImportParamCalled, 1)
 	m.DotImportParamStub(file)
 }
 
+// DotImportVariadicParam is a stub for the MyInterface.DotImportVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) DotImportVariadicParam(files ...File) {
 	atomic.AddInt32(&m.DotImportVariadicParamCalled, 1)
 	m.DotImportVariadicParamStub(files...)
 }
 
+// SelfReferentialParam is a stub for the MyInterface.SelfReferentialParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) SelfReferentialParam(intf MyInterface) {
 	atomic.AddInt32(&m.SelfReferentialParamCalled, 1)
 	m.SelfReferentialParamStub(intf)
 }
 
+// SelfReferentialVariadicParam is a stub for the MyInterface.SelfReferentialVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) SelfReferentialVariadicParam(intf ...MyInterface) {
 	atomic.AddInt32(&m.SelfReferentialVariadicParamCalled, 1)
 	m.SelfReferentialVariadicParamStub(intf...)
 }
 
+// StructParam is a stub for the MyInterface.StructParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) StructParam(obj struct{ num int }) {
 	atomic.AddInt32(&m.StructParamCalled, 1)
 	m.StructParamStub(obj)
 }
 
+// StructVariadicParam is a stub for the MyInterface.StructVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) StructVariadicParam(objs ...struct{ num int }) {
 	atomic.AddInt32(&m.StructVariadicParamCalled, 1)
 	m.StructVariadicParamStub(objs...)
 }
 
+// EmbeddedStructParam is a stub for the MyInterface.EmbeddedStructParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) EmbeddedStructParam(obj struct{ int }) {
 	atomic.AddInt32(&m.EmbeddedStructParamCalled, 1)
 	m.EmbeddedStructParamStub(obj)
 }
 
+// EmbeddedStructVariadicParam is a stub for the MyInterface.EmbeddedStructVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) EmbeddedStructVariadicParam(objs ...struct{ int }) {
 	atomic.AddInt32(&m.EmbeddedStructVariadicParamCalled, 1)
 	m.EmbeddedStructVariadicParamStub(objs...)
 }
 
+// EmptyInterfaceParam is a stub for the MyInterface.EmptyInterfaceParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) EmptyInterfaceParam(intf interface{}) {
 	atomic.AddInt32(&m.EmptyInterfaceParamCalled, 1)
 	m.EmptyInterfaceParamStub(intf)
 }
 
+// EmptyInterfaceVariadicParam is a stub for the MyInterface.EmptyInterfaceVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) EmptyInterfaceVariadicParam(intf ...interface{}) {
 	atomic.AddInt32(&m.EmptyInterfaceVariadicParamCalled, 1)
 	m.EmptyInterfaceVariadicParamStub(intf...)
 }
 
+// InterfaceParam is a stub for the MyInterface.InterfaceParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) InterfaceParam(intf interface{ MyFunc(num int) error }) {
 	atomic.AddInt32(&m.InterfaceParamCalled, 1)
 	m.InterfaceParamStub(intf)
 }
 
+// InterfaceVariadicParam is a stub for the MyInterface.InterfaceVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) InterfaceVariadicParam(intf ...interface{ MyFunc(num int) error }) {
 	atomic.AddInt32(&m.InterfaceVariadicParamCalled, 1)
 	m.InterfaceVariadicParamStub(intf...)
 }
 
+// InterfaceVariadicFuncParam is a stub for the MyInterface.InterfaceVariadicFuncParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) InterfaceVariadicFuncParam(intf interface{ MyFunc(nums ...int) error }) {
 	atomic.AddInt32(&m.InterfaceVariadicFuncParamCalled, 1)
 	m.InterfaceVariadicFuncParamStub(intf)
 }
 
+// InterfaceVariadicFuncVariadicParam is a stub for the MyInterface.InterfaceVariadicFuncVariadicParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) InterfaceVariadicFuncVariadicParam(intf ...interface{ MyFunc(nums ...int) error }) {
 	atomic.AddInt32(&m.InterfaceVariadicFuncVariadicParamCalled, 1)
 	m.InterfaceVariadicFuncVariadicParamStub(intf...)
 }
 
+// EmbeddedInterfaceParam is a stub for the MyInterface.EmbeddedInterfaceParam
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) EmbeddedInterfaceParam(intf interface{ fmt.Stringer }) {
 	atomic.AddInt32(&m.EmbeddedInterfaceParamCalled, 1)
 	m.EmbeddedInterfaceParamStub(intf)
 }
 
+// UnnamedReturn is a stub for the MyInterface.UnnamedReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) UnnamedReturn() error {
 	atomic.AddInt32(&m.UnnamedReturnCalled, 1)
 	return m.UnnamedReturnStub()
 }
 
+// MultipleUnnamedReturn is a stub for the MyInterface.MultipleUnnamedReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) MultipleUnnamedReturn() (int, error) {
 	atomic.AddInt32(&m.MultipleUnnamedReturnCalled, 1)
 	return m.MultipleUnnamedReturnStub()
 }
 
+// BlankReturn is a stub for the MyInterface.BlankReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) BlankReturn() (_ error) {
 	atomic.AddInt32(&m.BlankReturnCalled, 1)
 	return m.BlankReturnStub()
 }
 
+// NamedReturn is a stub for the MyInterface.NamedReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) NamedReturn() (err error) {
 	atomic.AddInt32(&m.NamedReturnCalled, 1)
 	return m.NamedReturnStub()
 }
 
+// SameTypeNamedReturn is a stub for the MyInterface.SameTypeNamedReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) SameTypeNamedReturn() (err1 error, err2 error) {
 	atomic.AddInt32(&m.SameTypeNamedReturnCalled, 1)
 	return m.SameTypeNamedReturnStub()
 }
 
+// RenamedImportReturn is a stub for the MyInterface.RenamedImportReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) RenamedImportReturn() (tmpl renamed.Template) {
 	atomic.AddInt32(&m.RenamedImportReturnCalled, 1)
 	return m.RenamedImportReturnStub()
 }
 
+// DotImportReturn is a stub for the MyInterface.DotImportReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) DotImportReturn() (file File) {
 	atomic.AddInt32(&m.DotImportReturnCalled, 1)
 	return m.DotImportReturnStub()
 }
 
+// SelfReferentialReturn is a stub for the MyInterface.SelfReferentialReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) SelfReferentialReturn() (intf MyInterface) {
 	atomic.AddInt32(&m.SelfReferentialReturnCalled, 1)
 	return m.SelfReferentialReturnStub()
 }
 
+// StructReturn is a stub for the MyInterface.StructReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) StructReturn() (obj struct{ num int }) {
 	atomic.AddInt32(&m.StructReturnCalled, 1)
 	return m.StructReturnStub()
 }
 
+// EmbeddedStructReturn is a stub for the MyInterface.EmbeddedStructReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) EmbeddedStructReturn() (obj struct{ int }) {
 	atomic.AddInt32(&m.EmbeddedStructReturnCalled, 1)
 	return m.EmbeddedStructReturnStub()
 }
 
+// EmptyInterfaceReturn is a stub for the MyInterface.EmptyInterfaceReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) EmptyInterfaceReturn() (intf interface{}) {
 	atomic.AddInt32(&m.EmptyInterfaceReturnCalled, 1)
 	return m.EmptyInterfaceReturnStub()
 }
 
+// InterfaceReturn is a stub for the MyInterface.InterfaceReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) InterfaceReturn() (intf interface{ MyFunc(num int) error }) {
 	atomic.AddInt32(&m.InterfaceReturnCalled, 1)
 	return m.InterfaceReturnStub()
 }
 
+// InterfaceVariadicFuncReturn is a stub for the MyInterface.InterfaceVariadicFuncReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) InterfaceVariadicFuncReturn() (intf interface{ MyFunc(nums ...int) error }) {
 	atomic.AddInt32(&m.InterfaceVariadicFuncReturnCalled, 1)
 	return m.InterfaceVariadicFuncReturnStub()
 }
 
+// EmbeddedInterfaceReturn is a stub for the MyInterface.EmbeddedInterfaceReturn
+// method that records the number of times it has been called.
 func (m *MyInterfaceMock) EmbeddedInterfaceReturn() (intf interface{ fmt.Stringer }) {
 	atomic.AddInt32(&m.EmbeddedInterfaceReturnCalled, 1)
 	return m.EmbeddedInterfaceReturnStub()

--- a/template.go
+++ b/template.go
@@ -8,6 +8,8 @@ import (
 	{{- end }}
 )
 
+// {{ .Name }}Mock is a mock implementation of the {{ .Name }}
+// interface.
 type {{ .Name }}Mock struct {
 	{{- range .Methods }}
 	{{ .Name }}Stub func({{ .Params }}) {{ .Results }}
@@ -19,6 +21,8 @@ var _ {{ .Name }} = &{{ .Name }}Mock{}
 
 {{- range .Methods }}
 
+// {{ .Name}} is a stub for the {{ $.Name }}.{{ .Name }}
+// method that records the number of times it has been called.
 func (m *{{ $.Name }}Mock) {{ .Name }}({{ .Params.NamedString }}) {{ .Results }}{
 	atomic.AddInt32(&m.{{ .Name }}Called, 1) 
 	{{- if gt (len .Results) 0 }}


### PR DESCRIPTION
**Motivation**

I frequently run the `golangci-lint` metalinter on packages containing mocks generated using the `mock` tool. I usually get warnings from `golint` like the following:

```
example.go|13 col 1| comment on exported type MyInterface should be of the form "MyInterface ..." (with optional leading article) (golint)
```

I got tired of seeing these linter warnings, and I didn't want to suppress this warning overall because I find it very useful for reminding me when I have a non-generated exported type for which I have forgotten to make a godoc-style comment.

**Changes:**
I added some godoc-style comments to the template for the generated mock struct and stubs in `template.go`, and I updated the examples and README correspondingly.

**Considerations:**
Cons: 
- The comments don't add much information to the mocks, since they essentially just repeat the information contained in the stub signatures.
Pros:
- They make the linter error go away ( :smile: ).
- The comments could flesh out a bit a godoc view of a package containing mocks generated with this tool.
